### PR TITLE
SO1S-341 database 노드그룹 Instance 사양 수정

### DIFF
--- a/live/dev/main.tf
+++ b/live/dev/main.tf
@@ -64,5 +64,5 @@ module "eks" {
 
     disk_size = 50
   }
-  database_node_instance_types = ["t3.nano"]
+  database_node_instance_types = ["t3.small"]
 }

--- a/live/prod/main.tf
+++ b/live/prod/main.tf
@@ -64,7 +64,7 @@ module "eks" {
 
     disk_size = 50
   }
-  database_node_instance_types = ["t3.nano"]
+  database_node_instance_types = ["t3.small"]
 }
 
 module "iam" {


### PR DESCRIPTION
# database 노드그룹 Instance 사양 수정

SO1S-341에서 nano일 경우 파드 갯수, 메모리 사양 등의 문제로 small 변경합니다.

## Tasks

- [x]  t3a.nano -> t3a.small로 변경


## Discussion

- 


## Jira

- SO1S-341