### PR TITLE
Hot-Fix: chagne model-builder spec

### DIFF
--- a/live/bootstrap.sh
+++ b/live/bootstrap.sh
@@ -55,7 +55,7 @@ done
 if [ $SO1S_USE_GPU_IN_BUILDER -eq 2 ]; then
   BUILDER_INSTANCE='["g4dn.xlarge"]'
 elif [ $SO1S_USE_GPU_IN_BUILDER -eq 1 ]; then
-  BUILDER_INSTANCE='["r6a.large"]'
+  BUILDER_INSTANCE='["r5a.large"]'
 fi
 
 cd $SO1S_ENV_PATH

--- a/live/dev/variables.tf
+++ b/live/dev/variables.tf
@@ -12,5 +12,5 @@ variable "inference_node_instance_types" {
 variable "model_builder_node_instance_types" {
   description = "This type will use inference node that use eks"
   type        = list(string)
-  default     = ["r6a.large"]
+  default     = ["r5a.large"]
 }

--- a/live/prod/variables.tf
+++ b/live/prod/variables.tf
@@ -13,5 +13,5 @@ variable "inference_node_instance_types" {
 variable "model_builder_node_instance_types" {
   description = "This type will use inference node that use eks"
   type        = list(string)
-  default     = ["r6a.large"]
+  default     = ["r5a.large"]
 }

--- a/modules/cluster/variables.tf
+++ b/modules/cluster/variables.tf
@@ -151,7 +151,7 @@ variable "model_builder_node_spot" {
 variable "model_builder_node_instance_types" {
   description = "This type will use model_builder node that use eks"
   type        = list(string)
-  default     = ["r6a.large"]
+  default     = ["r5a.large"]
 }
 
 variable "vpc_id" {


### PR DESCRIPTION
# chagne model-builder spec


## Tasks

- [x]  model builder 인스턴스 타입 변경


## Discussion

- ON_DEMAND여도 The following supplied instance types do not exist: [r6a.large] 에러가 발생하여 인스턴스 타입을 r6a -> r6a로 변경했습니다.


## Jira

- SO1S-512